### PR TITLE
wrong language constant in xml file

### DIFF
--- a/joomhighslide.xml
+++ b/joomhighslide.xml
@@ -2,12 +2,12 @@
 <extension version="3.0" type="plugin" group="joomgallery" method="upgrade">
   <name>PLG_JOOMGALLERY_JOOMHIGHSLIDE</name>
   <author>JoomGallery::ProjectTeam</author>
-  <creationDate>08.04.2013</creationDate>
-  <copyright>Copyright (C) 2012 - 2013 Open Source Matters. All rights reserved.</copyright>
+  <creationDate>29.09.2015</creationDate>
+  <copyright>Copyright (C) 2012 - 2015 Open Source Matters. All rights reserved.</copyright>
   <license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
   <authorEmail>team@joomgallery.net</authorEmail>
   <authorUrl>www.joomgallery.net</authorUrl>
-  <version>3.0</version>
+  <version>3.1</version>
   <description>PLG_JOOMGALLERY_JOOMHIGHSLIDE_XML_DESCRIPTION</description>
   <files>
     <filename plugin="joomhighslide">joomhighslide.php</filename>
@@ -32,7 +32,7 @@
   <config>
     <fields name="params">
       <fieldset name="basic">
-        <field name="global_box_existent" type="radio" default="0" label="PLG_JOOMGALLERY_JOOMHIGHSLIDE_GLOBAL_SHADOWBOX_EXISTENT_LABEL" description="PLG_JOOMGALLERY_JOOMHIGHSLIDE_GLOBAL_SHADOWBOX_EXISTENT_DESC">
+        <field name="global_box_existent" type="radio" default="0" label="PLG_JOOMGALLERY_JOOMHIGHSLIDE_GLOBAL_HIGHSLIDE_EXISTENT_LABEL" description="PLG_JOOMGALLERY_JOOMHIGHSLIDE_GLOBAL_HIGHSLIDE_EXISTENT_DESC">
           <option value="0">JNO</option>
           <option value="1">JYES</option>
         </field>


### PR DESCRIPTION
Die Sprachkonstante in der joomhighslide.xml stimmt nicht mit den Sprachdateien überein.
